### PR TITLE
chore: simplify langflow service healthcheck

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
       - QDRANT_HOST=qdrant
       - QDRANT_PORT=6333
     healthcheck:
-      test: ["CMD-SHELL", "python3 -c \"import socket; s=socket.socket(); s.connect(('localhost', 7860)) or exit(0); s.close()\" || exit 1"]
+      test: ["CMD-SHELL", "python3 -c 'import socket; s=socket.socket(); s.connect((\"localhost\", 7860)); s.close()'"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
Simplify langflow service healthcheck by removing unnecessary logic since Python's socket.connect() will naturally exit with appropriate status codes.